### PR TITLE
Fix static asset 404 errors by updating base path configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,8 +6,8 @@ const isProd = process.env.NODE_ENV === 'production';
 const nextConfig: NextConfig = {
     output: 'export',
     images: { unoptimized: true },
-    basePath: isProd ? '/portfolio-cli' : '',
-    assetPrefix: isProd ? '/portfolio-cli/' : '',
+    // basePath: isProd ? '' : '',
+    // assetPrefix: isProd ? '' : '',
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request addresses an issue where static assets were returning 404 errors by removing the portfolio-cli's base path configuration. Static assets will now be served directly from the root domain, resolving the issue.